### PR TITLE
Implement map weather framework for the Ferrothorn

### DIFF
--- a/theDefault/pom.xml
+++ b/theDefault/pom.xml
@@ -16,7 +16,7 @@
         <ModTheSpire.version>3.8.0</ModTheSpire.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!--CHANGE THIS TO YOUR STEAM INSTALLATION-->
-        <Steam.path>D:\Steam\steamapps</Steam.path>
+        <Steam.path>>D:\Steam\steamapps</Steam.path>
     </properties>
 
     <dependencies>

--- a/theDefault/src/main/java/ferrothorn/FerrothornMod.java
+++ b/theDefault/src/main/java/ferrothorn/FerrothornMod.java
@@ -69,7 +69,7 @@ import java.util.Properties;
  */
 
 @SpireInitializer
-public class FerrothornMod extends FerroWeatherSubscriber implements
+public class FerrothornMod implements
         EditCardsSubscriber,
         EditRelicsSubscriber,
         EditStringsSubscriber,
@@ -355,6 +355,7 @@ public class FerrothornMod extends FerroWeatherSubscriber implements
         
         BaseMod.registerModBadge(badgeTexture, MODNAME, AUTHOR, DESCRIPTION, settingsPanel);
 
+        BaseMod.subscribe(new FerroWeatherSubscriber());
         
         // =============== EVENTS =================
         

--- a/theDefault/src/main/java/ferrothorn/map/FerroWeatherMap.java
+++ b/theDefault/src/main/java/ferrothorn/map/FerroWeatherMap.java
@@ -6,8 +6,7 @@ import com.megacrit.cardcrawl.map.MapRoomNode;
 import com.megacrit.cardcrawl.random.Random;
 import com.megacrit.cardcrawl.rooms.MonsterRoom;
 import com.megacrit.cardcrawl.rooms.MonsterRoomElite;
-//import corruptthespire.Cor;
-//import corruptthespire.patches.core.WeatherField;
+import ferrothorn.characters.Ferrothorn;
 import ferrothorn.patches.WeatherField;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -18,33 +17,47 @@ import java.util.Collections;
 public class FerroWeatherMap {
     public static final Logger logger = LogManager.getLogger(FerroWeatherMap.class.getName());
 
-    public static void markCorruptedNodes() {
-        ArrayList<MapRoomNode> potentialCorruptNodes = new ArrayList<>();
+    public static void markWeatherNodes() {
+        Random rng = new Random(Settings.seed + AbstractDungeon.actNum);
+
+        ArrayList<MapRoomNode> potentialWeatherNodes = new ArrayList<>();
         for (int i = 0; i < AbstractDungeon.map.size(); i++) {
             for (int j = 0; j < AbstractDungeon.map.get(i).size(); j++) {
                 MapRoomNode node = AbstractDungeon.map.get(i).get(j);
                 if (node.getRoom() instanceof MonsterRoom || node.getRoom() instanceof MonsterRoomElite) {
-                    potentialCorruptNodes.add(node);
+                    potentialWeatherNodes.add(node);
                 }
             }
         }
-        Random rng = new Random(Settings.seed);
 
-        double percentCorrupt = .33;
-        int baseCorrupt = (int)Math.ceil(potentialCorruptNodes.size() * percentCorrupt);
-        System.out.println(baseCorrupt);
+        double percentCorrupt = 0.5;
+        int baseCorrupt = (int)Math.ceil(potentialWeatherNodes.size() * percentCorrupt);
 
-        Collections.shuffle(potentialCorruptNodes, rng.random);
+        Collections.shuffle(potentialWeatherNodes, rng.random);
 
         for (int i = 0; i < baseCorrupt; i++) {
-            MapRoomNode node = potentialCorruptNodes.get(i);
+            MapRoomNode node = potentialWeatherNodes.get(i);
             if (node != null) {
-                MarkCorrupted(node);
+                Ferrothorn.WeatherType weather = getRandomWeather(rng);
+                MarkWeather(node, weather);
             }
         }
     }
 
-    private static void MarkCorrupted(MapRoomNode node) {
-        //WeatherField.corrupted.set(node, true);
+    private static Ferrothorn.WeatherType getRandomWeather(Random rng) {
+        switch (rng.random(2)) {
+            case 0:
+                return Ferrothorn.WeatherType.Rain;
+            case 1:
+                return Ferrothorn.WeatherType.Sandstorm;
+            case 2:
+                return Ferrothorn.WeatherType.Sun;
+            default:
+                throw new RuntimeException("Impossible case");
+        }
+    }
+
+    private static void MarkWeather(MapRoomNode node, Ferrothorn.WeatherType weather) {
+        WeatherField.weather.set(node, weather);
     }
 }

--- a/theDefault/src/main/java/ferrothorn/patches/FerroWeatherPatch.java
+++ b/theDefault/src/main/java/ferrothorn/patches/FerroWeatherPatch.java
@@ -1,127 +1,115 @@
-//package ferrothorn.patches;
-//
-//import basemod.ReflectionHacks;
-//import com.badlogic.gdx.Gdx;
-//import com.badlogic.gdx.graphics.Color;
-//import com.badlogic.gdx.graphics.Texture;
-//import com.badlogic.gdx.graphics.g2d.SpriteBatch;
-//import com.badlogic.gdx.math.MathUtils;
-//import com.evacipated.cardcrawl.modthespire.lib.*;
-//import com.megacrit.cardcrawl.core.Settings;
-//import com.megacrit.cardcrawl.helpers.Hitbox;
-//import com.megacrit.cardcrawl.map.DungeonMap;
-//import com.megacrit.cardcrawl.map.MapRoomNode;
-//import com.megacrit.cardcrawl.screens.DungeonMapScreen;
-//import com.megacrit.cardcrawl.vfx.FlameAnimationEffect;
-//import ferrothorn.FerrothornMod;
-//import ferrothorn.map.FerroWeatherMap;
-//import ferrothorn.util.TextureLoader;
-//import javassist.CtBehavior;
-//
-//import java.util.ArrayList;
-//
-//public class FerroWeatherPatch {
-//    private static final Texture RAIN = TextureLoader.getTexture(FerrothornMod.makeUiPath("storm64.png"));
-//    private static final Texture SUN = TextureLoader.getTexture(FerrothornMod.makeUiPath("sun64.png"));
-//    private static final Texture SAND = TextureLoader.getTexture(FerrothornMod.makeUiPath("sandstorm64.png"));
-//    private static final int WIDTH = 64;
-//    private static final int HEIGHT = 64;
-//    private static final float GLOW_CYCLE = 2.0F;
-//    private static final float ALPHA_RANGE = 0.20F;
-//
-//    @SpirePatch(clz = MapRoomNode.class, method = "render", paramtypez = {SpriteBatch.class})
-//    public static class RenderPatch {
-//        @SpireInsertPatch(locator = RenderPatch.Locator.class)
-//        public static void renderCorruptedVfx(MapRoomNode __instance, SpriteBatch sb, float ___flameVfxTimer, ArrayList<FlameAnimationEffect> ___fEffects, float ___scale) {
-//            if (WeatherField.corrupted.get(__instance)) {
-//                int imgWidth = ReflectionHacks.getPrivate(__instance, MapRoomNode.class, "IMG_WIDTH");
-//                float scale = ReflectionHacks.getPrivate(__instance, MapRoomNode.class, "scale");
-//                float offsetX = ReflectionHacks.getPrivateStatic(MapRoomNode.class, "OFFSET_X");
-//                float offsetY = ReflectionHacks.getPrivateStatic(MapRoomNode.class, "OFFSET_Y");
-//                float spacingX = ReflectionHacks.getPrivateStatic(MapRoomNode.class, "SPACING_X");
-//
-//                sb.setColor(Color.WHITE);
-//                if (!Settings.isMobile) {
-//                    sb.draw(RAIN, (float)__instance.x * spacingX + offsetX - 64.0F + __instance.offsetX + imgWidth * scale, (float)__instance.y * Settings.MAP_DST_Y + offsetY + DungeonMapScreen.offsetY - 64.0F + __instance.offsetY, 64.0F, 64.0F, 128.0F, 128.0F, scale * Settings.scale, scale * Settings.scale, 0.0F, 0, 0, 128, 128, false, false);
-//                } else {
-//                    sb.draw(RAIN, (float)__instance.x * spacingX + offsetX - 64.0F + __instance.offsetX + imgWidth * scale, (float)__instance.y * Settings.MAP_DST_Y + offsetY + DungeonMapScreen.offsetY - 64.0F + __instance.offsetY, 64.0F, 64.0F, 128.0F, 128.0F, scale * Settings.scale * 2.0F, scale * Settings.scale * 2.0F, 0.0F, 0, 0, 128, 128, false, false);
-//                }
-//
-//                //exp10In interpolation with input range from 0.0 to 0.5 results in output range from 0.0 to 0.12
-//                //Future experiment can be to linearly map between those numbers instead
-//                //The value of 0.12F for the maximum additional scale here was reached by empirically examining the
-//                //interpolation that pulsing relics using, Interpolation.exp10In with an input range from 0.0 to 0.5,
-//                //and observing that it gives an output range of 0.0 to 0.12. This was then tweaked based on how things
-//                //looked with the various smoother interpolations (linear, sine).
-//                float maxAdditionalScale = 0.09F;
-//                float p = Math.abs((GLOW_CYCLE / 2.0F) - ___flameVfxTimer) / (GLOW_CYCLE / 2.0F);
-//                //float tmp = Interpolation.exp10In.apply(0.0F, 4.0F, p / 2.0F);
-//                //float tmp = p * maxAdditionalScale;
-//                float tmp = (1.0F - MathUtils.sin(___flameVfxTimer / GLOW_CYCLE * MathUtils.PI)) * maxAdditionalScale;
-//                sb.setBlendFunction(770, 1);
-//                float alpha = p * ALPHA_RANGE;
-//                sb.setColor(new Color(1.0F, 1.0F, 1.0F, alpha));
-//                if (!Settings.isMobile) {
-//                    sb.draw(RAIN, (float)__instance.x * spacingX + offsetX - 64.0F + __instance.offsetX + imgWidth * scale, (float)__instance.y * Settings.MAP_DST_Y + offsetY + DungeonMapScreen.offsetY - 64.0F + __instance.offsetY, 64.0F, 64.0F, 128.0F, 128.0F, scale * Settings.scale + tmp, scale * Settings.scale + tmp, 0.0F, 0, 0, 128, 128, false, false);
-//                    sb.draw(RAIN, (float)__instance.x * spacingX + offsetX - 64.0F + __instance.offsetX + imgWidth * scale, (float)__instance.y * Settings.MAP_DST_Y + offsetY + DungeonMapScreen.offsetY - 64.0F + __instance.offsetY, 64.0F, 64.0F, 128.0F, 128.0F, scale * Settings.scale + tmp * 0.66F, scale * Settings.scale + tmp * 0.66F, 0.0F, 0, 0, 128, 128, false, false);
-//                    sb.draw(RAIN, (float)__instance.x * spacingX + offsetX - 64.0F + __instance.offsetX + imgWidth * scale, (float)__instance.y * Settings.MAP_DST_Y + offsetY + DungeonMapScreen.offsetY - 64.0F + __instance.offsetY, 64.0F, 64.0F, 128.0F, 128.0F, scale * Settings.scale + tmp * 0.33F, scale * Settings.scale + tmp * 0.33F, 0.0F, 0, 0, 128, 128, false, false);
-//                } else {
-//                    sb.draw(RAIN, (float)__instance.x * spacingX + offsetX - 64.0F + __instance.offsetX + imgWidth * scale, (float)__instance.y * Settings.MAP_DST_Y + offsetY + DungeonMapScreen.offsetY - 64.0F + __instance.offsetY, 64.0F, 64.0F, 128.0F, 128.0F, scale * Settings.scale * 2.0F + tmp, scale * Settings.scale * 2.0F + tmp, 0.0F, 0, 0, 128, 128, false, false);
-//                    sb.draw(RAIN, (float)__instance.x * spacingX + offsetX - 64.0F + __instance.offsetX + imgWidth * scale, (float)__instance.y * Settings.MAP_DST_Y + offsetY + DungeonMapScreen.offsetY - 64.0F + __instance.offsetY, 64.0F, 64.0F, 128.0F, 128.0F, scale * Settings.scale * 2.0F + tmp * 0.66F, scale * Settings.scale * 2.0F + tmp * 0.66F, 0.0F, 0, 0, 128, 128, false, false);
-//                    sb.draw(RAIN, (float)__instance.x * spacingX + offsetX - 64.0F + __instance.offsetX + imgWidth * scale, (float)__instance.y * Settings.MAP_DST_Y + offsetY + DungeonMapScreen.offsetY - 64.0F + __instance.offsetY, 64.0F, 64.0F, 128.0F, 128.0F, scale * Settings.scale * 2.0F + tmp * 0.33F, scale * Settings.scale * 2.0F + tmp * 0.33F, 0.0F, 0, 0, 128, 128, false, false);
-//                }
-//                sb.setBlendFunction(770, 771);
-//            }
-//        }
-//
-//        private static class Locator extends SpireInsertLocator {
-//            @Override
-//            public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
-//                Matcher finalMatcher = new Matcher.MethodCallMatcher(MapRoomNode.class, "renderEmeraldVfx");
-//                return LineFinder.findInOrder(ctMethodToPatch, finalMatcher);
-//            }
-//        }
-//    }
-//
-//    @SpirePatch(clz = MapRoomNode.class, method = "update")
-//    public static class UpdatePatch {
-//        @SpireInsertPatch(locator = UpdatePatch.Locator.class)
-//        public static void updateCorruptedVfx(MapRoomNode __instance, @ByRef float[] ___flameVfxTimer, ArrayList<FlameAnimationEffect> ___fEffects, Hitbox ___hb) {
-//            if (WeatherField.corrupted.get(__instance) && !__instance.hasEmeraldKey) {
-//                ___flameVfxTimer[0] -= Gdx.graphics.getDeltaTime();
-//
-//                if ( ___flameVfxTimer[0] < 0.0F) {
-//                    ___flameVfxTimer[0] = GLOW_CYCLE;
-//                }
-//            }
-//        }
-//
-//        private static class Locator extends SpireInsertLocator {
-//            @Override
-//            public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
-//                Matcher finalMatcher = new Matcher.MethodCallMatcher(MapRoomNode.class, "updateEmerald");
-//                return LineFinder.findInOrder(ctMethodToPatch, finalMatcher);
-//            }
-//        }
-//    }
-//
-//    @SpirePatch(clz = DungeonMap.class, method = "renderBossIcon")
-//    public static class RenderBossIconPatch {
-//        @SpirePostfixPatch
-//        private static void renderCorruptedVfx(DungeonMap __instance, SpriteBatch sb) {
-//            if (DungeonMap.boss != null) {
-//                if (FerroWeatherMap.isBossCorrupted()) {
-//                    float bossW = ReflectionHacks.getPrivateStatic(DungeonMap.class, "BOSS_W");
-//                    float bossH = (512.0F * 3/4) * Settings.scale;
-//                    float mapOffsetY = ReflectionHacks.getPrivateStatic(DungeonMap.class, "mapOffsetY");
-//                    float bossOffsetY = ReflectionHacks.getPrivateStatic(DungeonMap.class, "BOSS_OFFSET_Y");
-//                    float baseBossIconPosition = DungeonMapScreen.offsetY + mapOffsetY + bossOffsetY;
-//
-//                    Color baseMapColor = ReflectionHacks.getPrivate(__instance, DungeonMap.class, "baseMapColor");
-//                    sb.setColor(new Color(1.0F, 1.0F, 1.0F, baseMapColor.a));
-//                    sb.draw(RAIN, (float)Settings.WIDTH / 2.0F + bossW  * 3.0F / 8.0F, baseBossIconPosition + bossH, WIDTH, HEIGHT);
-//                }
-//            }
-//        }
-//    }
-//}
+package ferrothorn.patches;
+
+import basemod.ReflectionHacks;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.math.MathUtils;
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.helpers.Hitbox;
+import com.megacrit.cardcrawl.map.MapRoomNode;
+import com.megacrit.cardcrawl.screens.DungeonMapScreen;
+import com.megacrit.cardcrawl.vfx.FlameAnimationEffect;
+import ferrothorn.FerrothornMod;
+import ferrothorn.characters.Ferrothorn;
+import ferrothorn.util.TextureLoader;
+import javassist.CtBehavior;
+
+import java.util.ArrayList;
+
+public class FerroWeatherPatch {
+    private static final Texture RAIN = TextureLoader.getTexture(FerrothornMod.makeUiPath("storm64.png"));
+    private static final Texture SAND = TextureLoader.getTexture(FerrothornMod.makeUiPath("sandstorm64.png"));
+    private static final Texture SUN = TextureLoader.getTexture(FerrothornMod.makeUiPath("sun64.png"));
+    private static final float GLOW_CYCLE = 2.0F;
+    private static final float ALPHA_RANGE = 0.20F;
+
+    @SpirePatch(clz = MapRoomNode.class, method = "render", paramtypez = {SpriteBatch.class})
+    public static class RenderPatch {
+        @SpireInsertPatch(locator = RenderPatch.Locator.class)
+        public static void renderWeatherVfx(MapRoomNode __instance, SpriteBatch sb, float ___flameVfxTimer, ArrayList<FlameAnimationEffect> ___fEffects, float ___scale) {
+            Ferrothorn.WeatherType weather = WeatherField.weather.get(__instance);
+            if (weather != null) {
+                Texture weatherImage = getWeatherImage(weather);
+                int imgWidth = ReflectionHacks.getPrivate(__instance, MapRoomNode.class, "IMG_WIDTH");
+                float scale = ReflectionHacks.getPrivate(__instance, MapRoomNode.class, "scale");
+                float offsetX = ReflectionHacks.getPrivateStatic(MapRoomNode.class, "OFFSET_X");
+                float offsetY = ReflectionHacks.getPrivateStatic(MapRoomNode.class, "OFFSET_Y");
+                float spacingX = ReflectionHacks.getPrivateStatic(MapRoomNode.class, "SPACING_X");
+
+                sb.setColor(Color.WHITE);
+                if (!Settings.isMobile) {
+                    sb.draw(weatherImage, (float)__instance.x * spacingX + offsetX - 64.0F + __instance.offsetX + imgWidth * scale, (float)__instance.y * Settings.MAP_DST_Y + offsetY + DungeonMapScreen.offsetY - 64.0F + __instance.offsetY, 64.0F, 64.0F, 128.0F, 128.0F, scale * Settings.scale, scale * Settings.scale, 0.0F, 0, 0, 128, 128, false, false);
+                } else {
+                    sb.draw(weatherImage, (float)__instance.x * spacingX + offsetX - 64.0F + __instance.offsetX + imgWidth * scale, (float)__instance.y * Settings.MAP_DST_Y + offsetY + DungeonMapScreen.offsetY - 64.0F + __instance.offsetY, 64.0F, 64.0F, 128.0F, 128.0F, scale * Settings.scale * 2.0F, scale * Settings.scale * 2.0F, 0.0F, 0, 0, 128, 128, false, false);
+                }
+
+                //exp10In interpolation with input range from 0.0 to 0.5 results in output range from 0.0 to 0.12
+                //Future experiment can be to linearly map between those numbers instead
+                //The value of 0.12F for the maximum additional scale here was reached by empirically examining the
+                //interpolation that pulsing relics using, Interpolation.exp10In with an input range from 0.0 to 0.5,
+                //and observing that it gives an output range of 0.0 to 0.12. This was then tweaked based on how things
+                //looked with the various smoother interpolations (linear, sine).
+                float maxAdditionalScale = 0.09F;
+                float p = Math.abs((GLOW_CYCLE / 2.0F) - ___flameVfxTimer) / (GLOW_CYCLE / 2.0F);
+                //float tmp = Interpolation.exp10In.apply(0.0F, 4.0F, p / 2.0F);
+                //float tmp = p * maxAdditionalScale;
+                float tmp = (1.0F - MathUtils.sin(___flameVfxTimer / GLOW_CYCLE * MathUtils.PI)) * maxAdditionalScale;
+                sb.setBlendFunction(770, 1);
+                float alpha = p * ALPHA_RANGE;
+                sb.setColor(new Color(1.0F, 1.0F, 1.0F, alpha));
+                if (!Settings.isMobile) {
+                    sb.draw(weatherImage, (float)__instance.x * spacingX + offsetX - 64.0F + __instance.offsetX + imgWidth * scale, (float)__instance.y * Settings.MAP_DST_Y + offsetY + DungeonMapScreen.offsetY - 64.0F + __instance.offsetY, 64.0F, 64.0F, 128.0F, 128.0F, scale * Settings.scale + tmp, scale * Settings.scale + tmp, 0.0F, 0, 0, 128, 128, false, false);
+                    sb.draw(weatherImage, (float)__instance.x * spacingX + offsetX - 64.0F + __instance.offsetX + imgWidth * scale, (float)__instance.y * Settings.MAP_DST_Y + offsetY + DungeonMapScreen.offsetY - 64.0F + __instance.offsetY, 64.0F, 64.0F, 128.0F, 128.0F, scale * Settings.scale + tmp * 0.66F, scale * Settings.scale + tmp * 0.66F, 0.0F, 0, 0, 128, 128, false, false);
+                    sb.draw(weatherImage, (float)__instance.x * spacingX + offsetX - 64.0F + __instance.offsetX + imgWidth * scale, (float)__instance.y * Settings.MAP_DST_Y + offsetY + DungeonMapScreen.offsetY - 64.0F + __instance.offsetY, 64.0F, 64.0F, 128.0F, 128.0F, scale * Settings.scale + tmp * 0.33F, scale * Settings.scale + tmp * 0.33F, 0.0F, 0, 0, 128, 128, false, false);
+                } else {
+                    sb.draw(weatherImage, (float)__instance.x * spacingX + offsetX - 64.0F + __instance.offsetX + imgWidth * scale, (float)__instance.y * Settings.MAP_DST_Y + offsetY + DungeonMapScreen.offsetY - 64.0F + __instance.offsetY, 64.0F, 64.0F, 128.0F, 128.0F, scale * Settings.scale * 2.0F + tmp, scale * Settings.scale * 2.0F + tmp, 0.0F, 0, 0, 128, 128, false, false);
+                    sb.draw(weatherImage, (float)__instance.x * spacingX + offsetX - 64.0F + __instance.offsetX + imgWidth * scale, (float)__instance.y * Settings.MAP_DST_Y + offsetY + DungeonMapScreen.offsetY - 64.0F + __instance.offsetY, 64.0F, 64.0F, 128.0F, 128.0F, scale * Settings.scale * 2.0F + tmp * 0.66F, scale * Settings.scale * 2.0F + tmp * 0.66F, 0.0F, 0, 0, 128, 128, false, false);
+                    sb.draw(weatherImage, (float)__instance.x * spacingX + offsetX - 64.0F + __instance.offsetX + imgWidth * scale, (float)__instance.y * Settings.MAP_DST_Y + offsetY + DungeonMapScreen.offsetY - 64.0F + __instance.offsetY, 64.0F, 64.0F, 128.0F, 128.0F, scale * Settings.scale * 2.0F + tmp * 0.33F, scale * Settings.scale * 2.0F + tmp * 0.33F, 0.0F, 0, 0, 128, 128, false, false);
+                }
+                sb.setBlendFunction(770, 771);
+            }
+        }
+
+        private static Texture getWeatherImage(Ferrothorn.WeatherType weather) {
+            switch (weather) {
+                case Rain: return RAIN;
+                case Sandstorm: return SAND;
+                case Sun: return SUN;
+                default: throw new RuntimeException("Unrecognized weather type: " + weather);
+            }
+        }
+
+        private static class Locator extends SpireInsertLocator {
+            @Override
+            public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
+                Matcher finalMatcher = new Matcher.MethodCallMatcher(MapRoomNode.class, "renderEmeraldVfx");
+                return LineFinder.findInOrder(ctMethodToPatch, finalMatcher);
+            }
+        }
+    }
+
+    @SpirePatch(clz = MapRoomNode.class, method = "update")
+    public static class UpdatePatch {
+        @SpireInsertPatch(locator = UpdatePatch.Locator.class)
+        public static void updateCorruptedVfx(MapRoomNode __instance, @ByRef float[] ___flameVfxTimer, ArrayList<FlameAnimationEffect> ___fEffects, Hitbox ___hb) {
+            if (WeatherField.weather.get(__instance) != null && !__instance.hasEmeraldKey) {
+                ___flameVfxTimer[0] -= Gdx.graphics.getDeltaTime();
+
+                if ( ___flameVfxTimer[0] < 0.0F) {
+                    ___flameVfxTimer[0] = GLOW_CYCLE;
+                }
+            }
+        }
+
+        private static class Locator extends SpireInsertLocator {
+            @Override
+            public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
+                Matcher finalMatcher = new Matcher.MethodCallMatcher(MapRoomNode.class, "updateEmerald");
+                return LineFinder.findInOrder(ctMethodToPatch, finalMatcher);
+            }
+        }
+    }
+}

--- a/theDefault/src/main/java/ferrothorn/patches/GenerateMapPatch.java
+++ b/theDefault/src/main/java/ferrothorn/patches/GenerateMapPatch.java
@@ -1,0 +1,47 @@
+package ferrothorn.patches;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.dungeons.TheEnding;
+import ferrothorn.map.FerroWeatherMap;
+
+@SpirePatch(
+        clz = AbstractDungeon.class,
+        method = "generateMap"
+)
+@SpirePatch(
+        clz = TheEnding.class,
+        method = "generateSpecialMap"
+)
+@SpirePatch(
+        cls = "abyss.act.VoidAct",
+        method = "makeMap",
+        optional = true
+)
+@SpirePatch(
+        cls = "ruina.dungeons.UninvitedGuests",
+        method = "makeMap",
+        optional = true
+)
+@SpirePatch(
+        cls = "ruina.dungeons.UninvitedGuestsShort",
+        method = "makeMap",
+        optional = true
+)
+@SpirePatch(
+        cls = "ruina.dungeons.BlackSilence",
+        method = "makeMap",
+        optional = true
+)
+@SpirePatch(
+        cls = "paleoftheancients.dungeons.PaleOfTheAncients",
+        method = "makeMap",
+        optional = true
+)
+public class GenerateMapPatch {
+    @SpirePostfixPatch
+    public static void MarkCorruptedNodes() {
+        FerroWeatherMap.markWeatherNodes();
+    }
+}

--- a/theDefault/src/main/java/ferrothorn/patches/WeatherField.java
+++ b/theDefault/src/main/java/ferrothorn/patches/WeatherField.java
@@ -10,5 +10,5 @@ import ferrothorn.characters.Ferrothorn;
         method = SpirePatch.CLASS
 )
 public class WeatherField {
-    //public static final SpireField<Ferrothorn.WeatherType> corrupted = new SpireField<>(() -> );
+    public static final SpireField<Ferrothorn.WeatherType> weather = new SpireField<>(() -> null);
 }

--- a/theDefault/src/main/java/ferrothorn/subscribers/FerroWeatherSubscriber.java
+++ b/theDefault/src/main/java/ferrothorn/subscribers/FerroWeatherSubscriber.java
@@ -3,17 +3,30 @@ package ferrothorn.subscribers;
 import basemod.interfaces.OnStartBattleSubscriber;
 import com.megacrit.cardcrawl.actions.watcher.ChangeStanceAction;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
-import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.rooms.AbstractRoom;
-import com.megacrit.cardcrawl.rooms.MonsterRoom;
+import com.megacrit.cardcrawl.stances.AbstractStance;
+import ferrothorn.characters.Ferrothorn;
 import ferrothorn.patches.WeatherField;
+import ferrothorn.stances.HarshSunlight;
+import ferrothorn.stances.Rain;
+import ferrothorn.stances.Sandstorm;
 
 public class FerroWeatherSubscriber implements OnStartBattleSubscriber {
     @Override
     public void receiveOnBattleStart(AbstractRoom room) {
-        /*if (WeatherField.get(node) != null) {
-            System.out.println("Rain entrance");
-            AbstractDungeon.actionManager.addToTop(new ChangeStanceAction(new ferrothorn.stances.Rain()));
-        }*/
+        Ferrothorn.WeatherType weather = WeatherField.weather.get(AbstractDungeon.getCurrMapNode());
+        if (weather != null) {
+            AbstractStance stance = getStance(weather);
+            AbstractDungeon.actionManager.addToTop(new ChangeStanceAction(stance));
+        }
+    }
+
+    private static AbstractStance getStance(Ferrothorn.WeatherType weather) {
+        switch (weather) {
+            case Rain: return new Rain();
+            case Sandstorm: return new Sandstorm();
+            case Sun: return new HarshSunlight();
+            default: throw new RuntimeException("Unrecognized weather type: " + weather);
+        }
     }
 }


### PR DESCRIPTION
Happy to explain any part of this. Quick summary below

What the parts do:
* WeatherField: adds a new field to store the weather to each map node
* GenerateMapPatch: patches the code that generates maps in all the different places it exists (custom act 4s each have their own logic) and calls FerroWeatherMap
* FerroWeatherMap: runs when making the map for each act and determines which nodes get which weather
* FerroWeatherPatch: displays the icons for the different weather types on the map
* FerroWeatherSubscriber: checks for weather and changes stance at the start of combat

What you may want to modify:
* FerroWeatherMap.markWeatherNodes: you can change the logic for which nodes get which weather to be whatever you want. right now it marks 50% of the normal/elite fights with a random weather type each
* FerroWeatherPatch.renderWeatherVfx: you can change the visual effects. right now the weather images have a pulsing effect
The other files shouldn't need to be changed unless you do something like add another weather type.